### PR TITLE
Combine predicates for super-capf test/try-completion, fixes #38

### DIFF
--- a/cape.el
+++ b/cape.el
@@ -560,8 +560,14 @@ If INTERACTIVE is nil the function acts like a Capf."
                    (copy-sequence cache-candidates))
                   (_
                    (completion--some
-                    (pcase-lambda (`(,table . ,_plist))
-                      (complete-with-action action table str pred))
+                    (pcase-lambda (`(,table . ,plist))
+		      (let* ((pr (plist-get plist :predicate))
+			     (pred (if pr
+				       (if pred (lambda (x) ; satisfy both
+						  (and (funcall pred x) (funcall pr x)))
+					 pr)
+				     pred)))
+			(complete-with-action action table str pred)))
                     tables))))
               :exclusive 'no
               :company-prefix-length prefix-len


### PR DESCRIPTION
As discussed in #38, composing CAPFs using `cape-super-capf` leads to candidate selection issues.  At its core, this results from the test/try-completion logic, which ignores any `:predicate` keywords the constituent tables set in their plists.  In the case of `elisp-completion-at-point`, `:predicate` is set to a function which ignores unbound variables.  This is important because completion fragments are included (unbound) in obarray during completion, so by default, _every input_ tests as `t`.

This small fix combines the `pred` argument with the underlying table's `:predicate` (if any).