### PR TITLE
Add cape-bbdb for completing name and email from BBDB

### DIFF
--- a/README.org
+++ b/README.org
@@ -50,6 +50,7 @@ are not using Company as frontend.
 + ~cape-tex~: Complete unicode char from TeX command, e.g. ~\hbar~.
 + ~cape-sgml~: Complete unicode char from Sgml entity, e.g., ~&alpha~.
 + ~cape-rfc1345~: Complete unicode char using RFC 1345 mnemonics.
++ ~cape-bbdb~: Complete name and email from BBDB.
 
 * Configuration
 

--- a/cape.el
+++ b/cape.el
@@ -414,6 +414,44 @@ If INTERACTIVE is nil the function acts like a Capf."
         ,(cape--table-with-properties (cape--dict-words) :category 'cape-dict)
         ,@cape--dict-properties))))
 
+;;;;; cape-bbdb
+
+(declare-function bbdb-records "bbdb")
+(declare-function bbdb-record-field "bbdb")
+
+(defvar cape--bbdb-properties
+  (list :annotation-function (lambda (_) " BBDB")
+        :company-kind (lambda (_) 'text)
+        :exclusive 'no)
+  "Completion extra properties for `cape-bbdb'.")
+
+(defvar cape--bbdb-records nil)
+(defun cape--bbdb-records ()
+  "BBDB records formated like FIRSTNAME LASTNAME <email@example.com>."
+  (or cape--bbdb-records
+      (setq cape--bbdb-records
+            (mapcar #'cape--bbdb-record-format (bbdb-records)))))
+
+(defun cape--bbdb-record-format (record)
+  "Formats a BBDB record into a string like FIRSTNAME LASTNAME <email@example.com>."
+  (format "%s %s"
+          (bbdb-record-field record 'name)
+          (apply #'concat
+                 (mapcar (lambda (e) (concat "<" e ">"))
+                         (bbdb-record-field record 'mail)))))
+
+;;;###autoload
+(defun cape-bbdb (&optional interactive)
+  "Complete name from BBDB and insert with email.
+If INTERACTIVE is nil the function acts like a Capf."
+  (interactive (list t))
+  (if interactive
+      (cape--interactive #'cape-bbdb)
+    (let ((bounds (cape--bounds 'word)))
+      `(,(car bounds) ,(cdr bounds)
+        ,(cape--table-with-properties (cape--bbdb-records) :category 'cape-bbdb)
+        ,@cape--bbdb-properties))))
+
 ;;;;; cape-abbrev
 
 (defun cape--abbrev-tables ()


### PR DESCRIPTION
This PR adds a new capf taking inspiration from the [company-bbdb](https://github.com/company-mode/company-mode/blob/master/company-bbdb.el) backend and written in the style of the `cape-dict` capf.

I use [mu4e](https://www.djcbsoftware.nl/code/mu/mu4e/), and I've had great success combining this capf with the built-in capf provided by mu4e:

``` emacs-lisp
(add-to-list 'completion-at-point-functions (cape-super-capf #'cape-bbdb #'mu4e~compose-complete-contact))
```

Happy to hear any feedback on this capf.