### PR TITLE
Add Elixir keywords

### DIFF
--- a/cape-keyword.el
+++ b/cape-keyword.el
@@ -85,6 +85,23 @@
      "super" "switch" "synchronized" "template" "this" "throw" "true" "try"
      "typedef" "typeid" "typeof" "ubyte" "ucent" "uint" "ulong" "union"
      "unittest" "ushort" "version" "void" "volatile" "wchar" "while" "with")
+    (elixir-mode ;; https://hexdocs.pm/elixir/Kernel.html
+     "__CALLER__" "__DIR__" "__ENV__" "__MODULE__" "__STACKTRACE__"
+     "__aliases__" "__block__" "abs" "alias" "alias!" "and" "apply"
+     "binary_part" "binary_slice" "binding" "bit_size" "byte_size" "case" "ceil"
+     "cond" "dbg" "def" "defdelegate" "defexception" "defguard" "defguardp"
+     "defimpl" "defmacro" "defmacrop" "defmodule" "defoverridable" "defp"
+     "defprotocol" "defstruct" "destructure" "div" "elem" "exit" "floor" "fn"
+     "for" "function_exported?" "get_and_update_in" "get_in" "hd" "if" "import"
+     "in" "inspect" "is_atom" "is_binary" "is_bitstring" "is_boolean"
+     "is_exception" "is_float" "is_function" "is_integer" "is_list" "is_map"
+     "is_map_key" "is_nil" "is_number" "is_pid" "is_port" "is_reference"
+     "is_struct" "is_tuple" "length" "macro_exported?" "make_ref" "map_size"
+     "match?" "max" "min" "node" "not" "or" "pop_in" "put_elem" "put_in" "quote"
+     "raise" "receive" "rem" "require" "reraise" "round" "self" "send" "spawn"
+     "spawn_link" "spawn_monitor" "struct" "struct!" "super" "tap" "then"
+     "throw" "tl" "to_charlist" "to_string" "trunc" "try" "tuple_size" "unless"
+     "unquote" "unquote_splicing" "update_in" "use" "var!" "with")
     (erlang-mode ;; https://www.erlang.org/docs/20/reference_manual/introduction.html
      "after" "and" "andalso" "band" "begin" "bnot" "bor" "bsl" "bsr" "bxor"
      "case" "catch" "cond" "div" "end" "fun" "if" "let" "not" "of" "or" "orelse"


### PR DESCRIPTION
This adds keywords from Elixir. I scraped these off of the `Kernel` namespace (see the [docs](https://hexdocs.pm/elixir/Kernel.html)) which gets auto-imported everywhere. This might as well be considered the builtins of the language.