### PR TITLE
Add cape-yasnippet

### DIFF
--- a/README.org
+++ b/README.org
@@ -48,6 +48,7 @@ advantage of Company backends even if you are not using Company as frontend.
 + ~cape-tex~: Complete Unicode char from TeX command, e.g. ~\hbar~.
 + ~cape-sgml~: Complete Unicode char from SGML entity, e.g., ~&alpha~.
 + ~cape-rfc1345~: Complete Unicode char using RFC 1345 mnemonics.
++ ~cape-yasnippet~: Complete and expand snippets registered with [[https://github.com/joaotavora/yasnippet][yasnippet]].
 
 * Configuration
 
@@ -80,7 +81,8 @@ popular ~use-package~ macro.
          ("C-c p _" . cape-tex)
          ("C-c p ^" . cape-tex)
          ("C-c p &" . cape-sgml)
-         ("C-c p r" . cape-rfc1345))
+         ("C-c p r" . cape-rfc1345)
+         ("C-c p y" . cape-yasnippet))
   :init
   ;; Add `completion-at-point-functions', used by `completion-at-point'.
   ;; NOTE: The order matters!
@@ -96,6 +98,7 @@ popular ~use-package~ macro.
   ;;(add-to-list 'completion-at-point-functions #'cape-dict)
   ;;(add-to-list 'completion-at-point-functions #'cape-symbol)
   ;;(add-to-list 'completion-at-point-functions #'cape-line)
+  ;;(add-to-list 'completion-at-point-functions #'cape-yasnippet)
 )
 #+end_src
 

--- a/cape-char.el
+++ b/cape-char.el
@@ -26,8 +26,6 @@
 
 (require 'cape)
 
-(autoload 'thing-at-point-looking-at "thingatpt")
-
 ;; Declare as pure function which is evaluated at compile time. We don't use a
 ;; macro for this computation since packages like `helpful' will
 ;; `macroexpand-all' the expensive `cape-char--define' macro calls.


### PR DESCRIPTION
This CAPF previews snippets and initiates their expansion upon selection. It's based on yasnippet, which takes over on `corfu-insert`. If popupinfo is configured, a preview of the expansion is also shown there, with placeholders for cursor positions like `<1>`, `<2>` and `<END>`.

The need came from and the implementation was developed for https://github.com/doomemacs/doomemacs/pull/7002. A slightly older version is vendored there for the time being, but it was requested that it be moved out and I agree it should. There should be no reliance on Doom in this PR.

Before creating my own package just with that code, I decided to ask if it fits here. Although the (partial) dependence on `yasnippet` may be off-putting, it's implemented with declarations and checks like the ones in the `company` adapter, so I thought it might be fine. Plus, it turned out smaller than I thought it would.

I can address any requests for changes or, if  it is not in scope, I will create a separate repository.