### PR TITLE
cape-char.el: Better implementation of translation hash function

### DIFF
--- a/cape-char.el
+++ b/cape-char.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'cape)
+(require 'quail)
 
 (autoload 'thing-at-point-looking-at "thingatpt")
 
@@ -32,37 +33,27 @@
 ;; macro for this computation since packages like `helpful' will
 ;; `macroexpand-all' the expensive `cape-char--define' macro calls.
 (eval-when-compile
-  (defun cape-char--translation (method regexp)
-    "Return character translation hash for METHOD.
-REGEXP is the regular expression matching the names."
+  (defun cape-char--translation (method)
+    "Return character translation hash for METHOD."
     (declare (pure t))
-    (save-window-excursion
-      (describe-input-method method)
-      (with-current-buffer "*Help*"
-        (let ((lines
-               (split-string
-                (replace-regexp-in-string
-                 "\n\n\\(\n\\|.\\)*" ""
-                 (replace-regexp-in-string
-                  "\\`\\(\n\\|.\\)*?----\n" ""
-                  (replace-regexp-in-string
-                   "\\`\\(\n\\|.\\)*?KEY SEQUENCE\n-+\n" ""
-                   (buffer-string))))
-                "\n"))
-              (hash (make-hash-table :test #'equal)))
-          (dolist (line lines)
-            (let ((beg 0) (len (length line)))
-              (while (< beg len)
-                (let* ((ename (next-single-property-change beg 'face line len))
-                       (echar (next-single-property-change ename 'face line len)))
-                  (when (and (get-text-property beg 'face line) (< ename len) (<= echar len))
-                    (let ((name (string-trim (substring-no-properties line beg ename)))
-                          (char (string-trim (substring-no-properties line ename echar))))
-                      (when (and (string-match-p regexp name) (length= char 1))
-                        (puthash name (aref char 0) hash))))
-                  (setq beg echar)))))
-          (kill-buffer)
-          hash)))))
+    (let* ((decode-map (list 'dm))
+           (quail-current-package (assoc method quail-package-alist))
+           (map-list (nth 2 quail-current-package))
+           (hash (make-hash-table :test #'equal)))
+      (apply #'quail-use-package method (nthcdr 5 (assoc method input-method-alist)))
+      (quail-build-decode-map (list map-list) "" decode-map 0)
+      (dolist (elem (cdr decode-map))
+        (let ((key (car elem))
+              (value (cdr elem)))
+          ;; Drop all translations that map to multiple candidates, like
+          ;; how quail hide them from "KEY SEQUENCES"
+          (if (not (vectorp value))
+              (puthash key (if (stringp value)
+                               (string-to-char value)
+                             value)
+                       hash))))
+      (quail-deactivate)
+      hash)))
 
 (defmacro cape-char--define (name method &rest prefix)
   "Define character translation capf.
@@ -78,9 +69,7 @@ PREFIX are the prefix characters."
         (properties (intern (format "cape--%s-properties" name)))
         (thing-re (concat (regexp-opt (mapcar #'char-to-string prefix)) "[^ \n\t]*" )))
     `(progn
-       (defvar ,hash (cape-char--translation
-                      ,method
-                      ,(concat "\\`" (regexp-opt (mapcar #'char-to-string prefix)))))
+       (defvar ,hash (cape-char--translation ,method))
        (defcustom ,prefix-required t
          ,(format "Initial prefix is required for `%s' to trigger." capf)
          :type 'boolean

--- a/cape-char.el
+++ b/cape-char.el
@@ -28,15 +28,15 @@
 
 (autoload 'thing-at-point-looking-at "thingatpt")
 
-(defun cape-char--ensure-str (char-or-str)
-  "Return CHAR-OR-STR as a string"
-  (if (characterp char-or-str)
-      (char-to-string char-or-str) char-or-str))
+(defmacro cape-char--ensure-str (char-or-str)
+  "IF-expression to convert CHAR-OR-STR to string only if it's a char"
+  `(if (characterp ,char-or-str)
+      (char-to-string ,char-or-str) ,char-or-str))
 
-(defun cape-char--ensure-char (char-or-str)
-  "Return CHAR-OR-STR as a char"
-  (if (stringp char-or-str)
-      (string-to-char char-or-str) char-or-str))
+(defmacro cape-char--ensure-char (char-or-str)
+  "IF-expression to convert CHAR-OR-STR to char only if it's a string"
+  `(if (stringp ,char-or-str)
+      (string-to-char ,char-or-str) ,char-or-str))
 
 ;; Declare as pure function which is evaluated at compile time. We don't use a
 ;; macro for this computation since packages like `helpful' will

--- a/cape-char.el
+++ b/cape-char.el
@@ -72,11 +72,12 @@ PREFIX are the prefix characters."
         (docsig (intern (format "cape--%s-docsig" name)))
         (exit (intern (format "cape--%s-exit" name)))
         (properties (intern (format "cape--%s-properties" name)))
-        (thing-re (concat (regexp-opt (mapcar #'char-to-string prefix)) "[^ \n\t]*" )))
+        (thing-re (concat (regexp-opt (mapcar #'char-to-string prefix)) "[^ \n\t]*" ))
+        (hash-val (cape-char--translation-hash
+                   method
+                   (concat "\\`" (regexp-opt (mapcar #'char-to-string prefix))))))
     `(progn
-       (defvar ,hash (cape-char--translation-hash
-                      ,method
-                      ,(concat "\\`" (regexp-opt (mapcar #'char-to-string prefix)))))
+       (defvar ,hash ,hash-val)
        (defcustom ,prefix-required t
          ,(format "Initial prefix is required for `%s' to trigger." capf)
          :type 'boolean

--- a/cape-char.el
+++ b/cape-char.el
@@ -58,7 +58,7 @@ retain the original string; otherwise they are stored as chars."
     (apply #'quail-use-package method (nthcdr 5 (assoc method input-method-alist)))
     (let ((hash (make-hash-table :test #'equal))
           (decode-map (list 'dm)))
-      (quail-build-decode-map (list (nth 2 quail-current-package)) "" decode-map 0)
+      (quail-build-decode-map (list (quail-map)) "" decode-map 0)
       ;; Now decode-map contains: (dm (name . value) (name . value) ...)
       (dolist (cell (cdr decode-map))
         (let ((name (car cell)) (value (cdr cell))


### PR DESCRIPTION
My solution for getting a translation hash without parsing the help output, using quail, which (partly) closes #90.

Related issues and PRs: #61 #73 

## Implementation

- Uses `quail.el` from emacs
- Obtains input method info from `input-method-alist` the same as how `describe-input-method` does it
- Uses `quail-build-decode-map` to obtain an (association?) list of the translation mappings, just like how quail does it to construct what we see in "KEY SEQUENCES"

## Changes outline

- Cape char
  - `cape-char--translation`
    - how the translation is fetched. Now quail.el is used, which means this function only supports quail-based input methods
    - format of values in hash table (both char and string are now stored)
    - multi-width strings for translation mappings (such as emoji flags) are hence now supported
    - removed pure function declaration and `eval-when-compile`
  - `cape-char--define`
    - references of the translation hash updated to adapt handling of both char and string
  - ~~(new) `cape-char--ensure-str` and `cape-char--ensure-char` convenience functions aiding the new hash table format~~ [`1e89ad2`](https://github.com/minad/cape/pull/91/commits/1e89ad26ae0a8ce72a7339efe542224d6e38cfb6)

## Notes

<details open>
<summary>toggle</summary>
<ul>
<li> <p>

~~The `regexp` argument has been removed since I don't see any difference in the result -- seems to work during initial testing~~ (reverted in [`8a58051`](https://github.com/minad/cape/pull/91/commits/8a5805143e5b84855b7be9b196224e657c8b90b9) to keep hash table filtered and its size small)
</p></li>

<li><p>


`(if (string= (char-to-string value-char) value-str)`:
  
  `string-width` exists, and it's probably correct to say that all "characters" that lose its original string form when converted from string to char and back to string, have string-width of 2. However there are strings that satisfy the latter, but still retain the original string when converted into char and back to string. Hence I decided to use the more verbose check for explicitness

</p></li>

<li><p>

`quail-build-decode-map`, the function that does the quintessential work in this whole PR, does accept the "KEY" argument, which actually applies filtering so the resulting decode-map only includes those with names beginning with KEY. (ie: you can pass KEY as ":" for emoji and ones with the name not beginning with ":" would be excluded.)
  
  However I've decided to stick to the original regexp argument, since we're looping over each name-value cons cell anyway, and `string-match` isn't that slow (plus the translation function is only called ones during initial definition of each char capf). Furthermore using regexp allows extensions to the functionality in the future where we wouldn't be only limited to prefixes, if ever.

</p></li>

<li><p>

~~Using `(nth 2 quail-current-package)` rather than `(quail-map)` (the two do the same thing)~~

  ~~This probably has the disadvantage of having maintenance if quail ever changes their format of `quail-current-package` data, but 1) its format seems unlikely to change (I think!), and 2) it avoids another reference to a symbol that the warning may say is undefined (again, not a strong argument)~~

Now using `(quail-map)`, see [`884ad0d`](https://github.com/minad/cape/pull/91/commits/884ad0d83c3190f579f7b9570a9a85f8ab691cba)

</li>

<li>There is (I think) a kind of unfixable effect of allowing both strings and chars in the hash table (especially due to some "characters" not being able to be represented as a character type).

  In the `cape-char--define` macro where the `*docsig` function is defined, we use functions that act strictly on characters to fetch meta information on the character of completion candidates. If the value from gethash is a string, then it can't be fully represented as a character, so one could say the resulting `get-char-code-property` is incorrect? I did a quick web-search and couldn't find a suitable solution in getting char code property for these special "characters"

```elisp
(get-char-code-property (string-to-char "🇦🇨") 'name)
; => "REGIONAL INDICATOR SYMBOL A"
(char-code-property-description 'general-category (get-char-code-property (string-to-char "🇦🇨") 'general-category))
; => "Symbol, Other"
```

  I think it's somewhat informative 🤷 

</li>
</ul>
</details>

## Caveats/Limitations

- This implementation only works for input methods that uses quail.
   However this would actually cover the majority of the input methods; for my install it looks like only a few Korean input methods and UCS input method does not use quail. No idea how the support for them is for the old implementation (in describe-input-method)

## TODO

- [x] For handling of vectors in the decode map, keep ones where it's a vector of only one item
- [x] store either char or string depending on whether converting char back to string retains the original string
- [x] filter out unmatched prefixes from hash table
- [x] Test package ~~(works with loading from custom load-path, but not with a package manager that byte-compiles packages) :')~~ (fixed in [`2945693`](https://github.com/minad/cape/pull/91/commits/294569342d4e1ab2458af6df49c35a7711bd5c98)) tested with emacs 28 and 29

## Demo
<details open>
<summary>toggle</summary>
<br>



emacs 29:

<img width="500" alt="image" src="https://github.com/minad/cape/assets/50042066/8f4106c9-03fc-4376-a37b-2a4bdd450665"><br>

emacs 28:

<img width="500" alt="image" src="https://github.com/minad/cape/assets/50042066/4a4d528b-6f3a-41b7-bd17-82a5b49a38aa"><br>

emacs 29:

<img width="500" alt="image" src="https://github.com/minad/cape/assets/50042066/4c00a36d-356a-402d-b8e1-fafd83e29882"><br>

emacs 28:

With autoloaded `cape-char--define` and user's custom `(cape-char--define TeX "TeX" ?\\)` call in the config

<img width="500" alt="Screenshot 2023-09-12 at 20 18 37" src="https://github.com/minad/cape/assets/50042066/d8ace30e-e047-498b-ac54-5b39150955eb"><br>

emacs 29:

```elisp
;; With "math-symbol-lists"
(cape-char--define math "math" ?\\)
(add-to-list 'completion-at-point-functions #'cape-math)
```

<img width="500" alt="image" src="https://github.com/minad/cape/assets/50042066/f238f67a-a252-46a3-b4b5-2b7d7eb06413">

</details>