### PR TITLE
cape-keyword: Update Python keywords

### DIFF
--- a/cape-keyword.el
+++ b/cape-keyword.el
@@ -259,10 +259,10 @@
      "in" "infix" "infixl" "infixr" "instance" "let" "module" "newtype" "of"
      "then" "type" "where")
     (python-mode ;; https://docs.python.org/3/reference/lexical_analysis.html#keywords
-     "False" "None" "True" "and" "as" "assert" "break" "class" "continue" "def"
-     "del" "elif" "else" "except" "exec" "finally" "for" "from" "global" "if"
-     "import" "in" "is" "lambda" "nonlocal" "not" "or" "pass" "print" "raise"
-     "return" "try" "while" "with" "yield")
+     "False" "None" "True" "and" "as" "assert" "break" "case ""class" "continue"
+     "def" "del" "elif" "else" "except" "exec" "finally" "for" "from" "global"
+     "if" "import" "in" "is" "lambda" "match ""nonlocal" "not" "or" "pass"
+     "print" "raise" "return" "try" "while" "with" "yield")
     (ruby-mode
      "BEGIN" "END" "alias" "and" "begin" "break" "case" "class" "def" "defined?"
      "do" "else" "elsif" "end" "ensure" "false" "for" "if" "in" "module" "next"


### PR DESCRIPTION
Python 3.10 added three new ["soft"][1] keywords: `match`, `case` and `_`.

Add `match` and `case` but skip `_` since a one-character keyword is of low use in completion.

[1]: https://docs.python.org/3/reference/lexical_analysis.html#soft-keywords