### PR TITLE
Add php-ts-mode as an alias of php-mode

### DIFF
--- a/cape-keyword.el
+++ b/cape-keyword.el
@@ -374,6 +374,7 @@
     (js-mode javascript-mode)
     (js2-jsx-mode javascript-mode)
     (js2-mode javascript-mode)
+    (php-ts-mode php-mode)
     (phps-mode php-mode)
     (rjsx-mode javascript-mode)
     (tuareg-mode caml-mode)


### PR DESCRIPTION
Add support for [php-ts-mode](https://github.com/emacs-php/php-ts-mode). This package is not yet available in any ELPA, but will be submitted to GNU ELPA in due course.

refs https://github.com/emacs-php/php-ts-mode/issues/55