### PR TITLE
cape-wrap-inside-faces: use (1- (point)) instead of (point)

### DIFF
--- a/cape.el
+++ b/cape.el
@@ -1116,7 +1116,8 @@ If the prefix is long enough, enforce auto completion."
 (defun cape-wrap-inside-faces (capf &rest faces)
   "Call CAPF only if inside FACES.
 This function can be used as an advice around an existing Capf."
-  (when-let ((fs (get-text-property (point) 'face))
+  (when-let ((fs (and (> (point) (point-min))
+                      (get-text-property (1- (point)) 'face)))
              ((if (listp fs)
                   (cl-loop for f in fs thereis (memq f faces))
                 (memq fs faces))))


### PR DESCRIPTION
This addresses #109 where we weren't picking up
`tree-sitter-hl-face:comment`. The problem is that when you use `(text-properties-at (point))`, it returns the properties of the character after the point, not the character before the point. To illustrate, running `(describe-char (point-max))` errors out with "No character follows specified position". When we are completing based on face, we always mean the face of the character immediately before the point.

To give a few examples of running `(list (get-text-property (1- (point)) 'face) (get-text-property (point) 'face))` :
![image](https://github.com/minad/cape/assets/29102529/3dc26468-ffa0-4bcd-9c41-b9031bd8e3d1)
^ Running that here produces `(font-lock-variable-name-face nil)`, and the left output makes more sense in the context that you are typing out a variable name.
![image](https://github.com/minad/cape/assets/29102529/2019f0fb-f003-400b-ad55-2917168b9cf4)
^ Running that here gives `(font-lock-comment-face font-lock-comment-face)` because Elisp font-locking applies the comment face to the newline character,
![image](https://github.com/minad/cape/assets/29102529/bfcf64e0-181e-4f75-acc4-b98b45b8185d)
^ Whereas running it here gives `(tree-sitter-hl-face:comment nil)` because `tree-sitter-hl` does not highlight the newline character.