### PR TITLE
Add autoload for cape-capf-sort

### DIFF
--- a/cape.el
+++ b/cape.el
@@ -1325,6 +1325,7 @@ See `%s' for documentation." name wrapper wrapper))))
 ;;;###autoload (autoload 'cape-capf-prefix-length "cape")
 ;;;###autoload (autoload 'cape-capf-properties "cape")
 ;;;###autoload (autoload 'cape-capf-silent "cape")
+;;;###autoload (autoload 'cape-capf-sort "cape")
 ;;;###autoload (autoload 'cape-capf-super "cape")
 ;;;###autoload (autoload 'cape-capf-trigger "cape")
 


### PR DESCRIPTION
Hi @minad

Thank you very much for your package! I noticed `cape-capf-sort` was not autoloaded. Here is a (little) PR about that.

Cheers,

Florian